### PR TITLE
Add url to Metadata for SOAP requests

### DIFF
--- a/cp/soap.go
+++ b/cp/soap.go
@@ -32,7 +32,7 @@ type soapHandler struct{ cshandler CentralSystemMessageHandler }
 func (s soapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Debug("New SOAP request")
 
-	err := soap.Handle(w, r, func(request messages.Request, cpID string) (messages.Response, error) {
+	err := soap.Handle(w, r, func(request messages.Request, cpID string, url string) (messages.Response, error) {
 		req, ok := request.(csreq.CentralSystemRequest)
 		if !ok {
 			return nil, errors.New("request is not a cprequest")

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -19,8 +19,9 @@ import (
 )
 
 type ChargePointRequestMetadata struct {
-	ChargePointID string
-	HTTPRequest   *http.Request
+	ChargePointID  string
+	ChargePointUrl string
+	HTTPRequest    *http.Request
 }
 
 // ChargePointMessageHandler handles the OCPP messages coming from the charger
@@ -167,14 +168,15 @@ func (csys *centralSystem) handleWebsocket(w http.ResponseWriter, r *http.Reques
 
 func (csys *centralSystem) handleSoap(w http.ResponseWriter, r *http.Request, cphandler ChargePointMessageHandler) {
 	log.Debug("New SOAP request")
-	err := soap.Handle(w, r, func(request messages.Request, cpID string) (messages.Response, error) {
+	err := soap.Handle(w, r, func(request messages.Request, cpID string, url string) (messages.Response, error) {
 		req, ok := request.(cpreq.ChargePointRequest)
 		if !ok {
 			return nil, errors.New("request is not a cprequest")
 		}
 		return cphandler(req, ChargePointRequestMetadata{
-			ChargePointID: cpID,
-			HTTPRequest:   r,
+			ChargePointID:  cpID,
+			ChargePointUrl: url,
+			HTTPRequest:    r,
 		})
 	})
 	if err != nil {

--- a/ocpp.go
+++ b/ocpp.go
@@ -5,7 +5,7 @@ import (
 	"github.com/voltbras/go-ocpp/messages"
 )
 
-type MessageHandler func(request messages.Request, cpID string) (messages.Response, error)
+type MessageHandler func(request messages.Request, cpID string, url string) (messages.Response, error)
 
 type Version string
 

--- a/soap/server.go
+++ b/soap/server.go
@@ -30,7 +30,7 @@ func Handle(w http.ResponseWriter, r *http.Request, handle ocpp.MessageHandler) 
 		return errors.New("received message is not a request")
 	}
 
-	resp, err := handle(req, reqEnv.Header.ChargeBoxIdentity)
+	resp, err := handle(req, reqEnv.Header.ChargeBoxIdentity, reqEnv.Header.From.Address)
 	if err != nil {
 		log.Error("couldn't handle request: %w", err)
 	}


### PR DESCRIPTION
For soap requests the charge point url was not parsed from the incoming connections.

By adding this, the central system can dynamically respond back to the charge point